### PR TITLE
Set INSTALL_RPATH in UNIX for RenderDocHost to resolve renderdoc lib correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,7 +324,7 @@ endif()
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
-if(APPLE AND NOT JETBRAINS)
+if(APPLE)
     # For Xcode set the output directory to be the same for all configurations
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/lib")
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/bin")

--- a/jetbrains/CMakeLists.txt
+++ b/jetbrains/CMakeLists.txt
@@ -27,7 +27,7 @@ else ()
     FetchContent_Declare(rd SOURCE_DIR ${RD_FETCH_PATH})
 endif ()
 
-FetchContent_Populate(rd)
+FetchContent_MakeAvailable(rd)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/jetbrains/rd-host/CMakeLists.txt
+++ b/jetbrains/rd-host/CMakeLists.txt
@@ -12,4 +12,17 @@ if (ENABLE_PCH_HEADERS)
     add_precompiled_header(RenderDocHost pch.h SOURCE_CXX pch.cpp FORCEINCLUDE)
 endif ()
 
+if (APPLE)
+    set_target_properties(RenderDocHost PROPERTIES
+            INSTALL_RPATH "@executable_path"
+            BUILD_WITH_INSTALL_RPATH FALSE
+            MACOSX_RPATH TRUE
+    )
+elseif (UNIX)
+    set_target_properties(RenderDocHost PROPERTIES
+            INSTALL_RPATH "$ORIGIN"
+            BUILD_WITH_INSTALL_RPATH FALSE
+    )
+endif()
+
 target_link_libraries(RenderDocHost PRIVATE RenderDocService RenderDocRoot)


### PR DESCRIPTION
By default, `RenderDocHost` doesn't search for `librenderdoc.xx`  in the same folder and fails when executed on machine that was not the one where it was built