### PR TITLE
Deferred port completed exceptionally when no port found

### DIFF
--- a/jetbrains/src/main/kotlin/com/jetbrains/renderdoc/rdClient/RenderDocClient.kt
+++ b/jetbrains/src/main/kotlin/com/jetbrains/renderdoc/rdClient/RenderDocClient.kt
@@ -9,6 +9,9 @@ import com.jetbrains.renderdoc.rdClient.model.RenderDocModel
 import com.jetbrains.renderdoc.rdClient.model.renderDocModel
 
 @PublicApi
+class RenderDocHostException(val exitCode: Int) : RuntimeException("RenderDocHost process exited with $exitCode code")
+
+@PublicApi
 class RenderDocClient(lifetime: Lifetime, @PublicApi val scheduler: IScheduler, sessionId: Long, port: Int) {
     companion object {
         suspend fun createWithHost(lifetime: Lifetime, scheduler: IScheduler, sessionId: Long, binDir: String): RenderDocClient {

--- a/jetbrains/src/main/kotlin/com/jetbrains/renderdoc/rdClient/RenderDocHost.kt
+++ b/jetbrains/src/main/kotlin/com/jetbrains/renderdoc/rdClient/RenderDocHost.kt
@@ -44,8 +44,9 @@ internal class RenderDocHost(private val lifetime: Lifetime, binDir: String) {
             deferredPort = CompletableDeferred()
 
             deferredExitCode.invokeOnCompletion { ex ->
-                deferredPort.completeExceptionally(ex ?: IllegalStateException("RenderDocHost process was terminated with exit code ${process.exitValue()}"))
-                serverLogger.info { "RenderDocHost exited with ${process.exitValue()} code" }
+                val exitCode = process.exitValue()
+                deferredPort.completeExceptionally(RenderDocHostException(exitCode))
+                serverLogger.info { "RenderDocHost exited with $exitCode code" }
             }
 
             // Detailed methods to handle processDataReceived, errorDataReceived and logHostMessage are omitted for brevity

--- a/jetbrains/src/main/kotlin/com/jetbrains/renderdoc/rdClient/RenderDocHost.kt
+++ b/jetbrains/src/main/kotlin/com/jetbrains/renderdoc/rdClient/RenderDocHost.kt
@@ -41,9 +41,10 @@ internal class RenderDocHost(private val lifetime: Lifetime, binDir: String) {
             val serverLogger = getLogger("RenderDocHost")
             val process = processBuilder.start()
             deferredExitCode = process.onExit().asDeferred()
-            deferredPort = CompletableDeferred(deferredExitCode)
+            deferredPort = CompletableDeferred()
 
-            deferredExitCode.invokeOnCompletion {
+            deferredExitCode.invokeOnCompletion { ex ->
+                deferredPort.completeExceptionally(ex ?: IllegalStateException("RenderDocHost process was terminated with exit code ${process.exitValue()}"))
                 serverLogger.info { "RenderDocHost exited with ${process.exitValue()} code" }
             }
 
@@ -84,13 +85,14 @@ internal class RenderDocHost(private val lifetime: Lifetime, binDir: String) {
             }
 
             lifetime.onTermination {
+                deferredPort.cancel()
                 process.destroy()
                 process.waitFor(1, TimeUnit.SECONDS)
             }
         }
     }
 
-    suspend fun getPort() = deferredPort.await()
+    suspend fun getPort(): Int = deferredPort.await()
 
     private fun logHostMessage(serverLogger: Logger, defaultLogLevel: LogLevel, message: String) {
         val matcher = HostMessageRegex.matcher(message)


### PR DESCRIPTION
With previous library versions, when RenderDocHost process fails and exits before port was written to stdout, `getPort() = deferredPort.await()` hanged even with explicit exceptional cancelation in `deferredExitCode.invokeOnCompletion`. So I needed to initialise port deferred without `deferredExitCode` as a parent to make `deferredExitCode.invokeOnCompletion` be invoked and complete `deferredPort` with an exception in such case.